### PR TITLE
Project: env-driven GCP + time handling groundwork

### DIFF
--- a/realtime/main.py
+++ b/realtime/main.py
@@ -7,7 +7,7 @@ from google.cloud import pubsub_v1
 from google.api_core.exceptions import AlreadyExists
 
 # ─── CONFIG ──────────────────────────────────────────────
-PROJECT_ID = os.getenv("GCP_PROJECT", "ttbot-466703")
+PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT") or os.getenv("PROJECT_ID") or os.getenv("GCP_PROJECT") or "tt-production-468500"
 TOPIC      = os.getenv("PUBSUB_TOPIC", "my-streaming-ticks")
 SUB_ID     = os.getenv("PUBSUB_SUBSCRIPTION", "")
 SYMBOL     = os.getenv("SYMBOL", "SPY")

--- a/refresh-token/main.py
+++ b/refresh-token/main.py
@@ -1,8 +1,9 @@
+import os
 import requests
 import sys
 from google.cloud import secretmanager
 
-GCP_PROJECT_ID = "ttbot-466703"
+GCP_PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT") or os.getenv("PROJECT_ID") or "tt-production-468500"
 
 def access_secret(secret_id):
     client = secretmanager.SecretManagerServiceClient()
@@ -45,3 +46,6 @@ def refresh_token(request):
     set_secret("tastytrade-session-token", session_token)
     print("✅ Refreshed session token in Secret Manager.")
     return "OK", 200
+
+if __name__ == "__main__":
+    refresh_token(None)

--- a/streamer/stream_dxlink_pubsub.py
+++ b/streamer/stream_dxlink_pubsub.py
@@ -13,7 +13,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 
 # —————————————————————————————————————————————————————
 # CONFIGURATION
-GCP_PROJECT_ID      = os.getenv("GCP_PROJECT_ID", "ttbot-466703")
+GCP_PROJECT_ID      = os.getenv("GCP_PROJECT_ID") or os.getenv("GOOGLE_CLOUD_PROJECT") or os.getenv("PROJECT_ID") or "tt-production-468500"
 PUBSUB_TOPIC        = os.getenv("PUBSUB_TOPIC", "my-streaming-ticks")
 STREAM_SYMBOL       = os.getenv("STREAM_SYMBOL", "SPY")
 SESSION_SECRET_NAME = os.getenv("SESSION_SECRET_NAME", "tastytrade-session-token")


### PR DESCRIPTION
Switch to env-driven PROJECT_ID, prep for UTC+epoch_ms timestamps.